### PR TITLE
Document difference between two sizes in pdi table header

### DIFF
--- a/formats/pdt.md
+++ b/formats/pdt.md
@@ -33,7 +33,11 @@ If the compression flag is set, then this section is zlib-compressed.
 | Offset | Type    | Detail |
 |:-------|:--------|:-------|
 | `0`    | `uint16` | Num cells |
-| `2`    | `uint16` | Num cells again? |
+| `2`    | `uint16` | Num cells per row |
+
+For sequential image tables, the values will be the same.
+
+For matrix image tables, the second value will be the number of cells on each row.
 
 ### Table
 


### PR DESCRIPTION
The table header in a pdt file has two numbers. For a sequential image table, they're both the number of images. For a matrix image table, the first is the total number of images, while the second is the number of images per row.

(The change at the end is just adding a final newline.)