### PR TITLE
Note meaning of size in compressed image header

### DIFF
--- a/formats/pdt.md
+++ b/formats/pdt.md
@@ -24,6 +24,11 @@ If the compression flag is set, there's an extra header after the file header:
 | `8`    | `int32`  | Image height |
 | `12`   | `int32`  | Number of cells |
 
+The image width and height are for the first image only.
+In sequential image tables, the following images may be of
+different sizes.
+In matrix image tables, all images must be the same size.
+
 ## Image Data
 
 If the compression flag is set, then this section is zlib-compressed.


### PR DESCRIPTION
The image width and height in the compressed image header are for the first image only. For matrix image tables, this is the size for all of the images, but for sequential image tables, they may vary. Document this.